### PR TITLE
Add code to get sushi-emulator set up on Virtual Blades

### DIFF
--- a/vtds_application_openchami/private/__init__.py
+++ b/vtds_application_openchami/private/__init__.py
@@ -52,8 +52,9 @@ def home(filename):
     return path_join(separator, "root", filename)
 
 
-# source, dest, mode, tag, run
-DEPLOY_FILES = [
+# Templated files to be deployed to the managment node: (source, dest,
+# mode, tag, run)
+MANAGEMENT_NODE_FILES = [
     (
         template('magellan_discovery_dockerfile'),
         home('magellan_discovery_dockerfile'),
@@ -108,6 +109,31 @@ DEPLOY_FILES = [
         home('prepare_node.sh'),
         '755',
         'node_prepare_script',
+        True,
+    ),
+]
+
+# Templated files to be deployed to and run on the Virtual Blades
+BLADE_FILES = [
+    (
+        template('sushy-emulator.conf'),
+        home('sushy-emulator.conf'),
+        '644',
+        'sushy-emulator-configuration',
+        False
+    ),
+    (
+        template('sushy-emulator.service'),
+        home('sushy-emulator.service'),
+        '644',
+        'sushy-emulator-unit-file',
+        False
+    ),
+    (
+        template('prepare_blade.sh'),
+        home('prepare_blade.sh'),
+        '700',
+        'blade_prepare_script',
         True,
     ),
 ]

--- a/vtds_application_openchami/private/config/config.yaml
+++ b/vtds_application_openchami/private/config/config.yaml
@@ -51,6 +51,19 @@ application:
     internal:
       network_cidr: 172.25.0.0/24
       network_name: null
+      # Username and password used by RIE for redfish emulation. This is a
+      # short term fix until we are able to configure RIE endpoints more
+      # precisely. The password is not really a secret because it does not
+      # grant actual access to anything of interest.
+      redfish_username: root
+      redfish_password: root_password
     hardware_management:
       network_cidr: null
       network_name: hardware_management
+      # Username and password used by RedFish on the Virtual Blades. The
+      # password here grants access to the Virtual Nodes of the cluster,
+      # so it is a bit more sensitive. It is generated and stuffed into
+      # the configuration automatically if it is null. Override it at your
+      # own risk if you want a known value.
+      redfish_username: root
+      redfish_password: null

--- a/vtds_application_openchami/private/templates/magellan_discovery.sh
+++ b/vtds_application_openchami/private/templates/magellan_discovery.sh
@@ -23,19 +23,25 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 set -eu -o pipefail
-export emulator_username={{ emulator_username }}
-export emulator_password={{ emulator_password }}
 export PATH=$PATH:/
+mkdir -p /tmp/nobody/magellan
+cd /tmp/nobody/magellan
 export MASTER_KEY=$(magellan secrets generatekey)
+echo MASTER_KEY > /tmp/nobody/magellan/master_key # Keep it around for debug
+export ACCESS_TOKEN=$(curl -s -X GET http://opaal:3333/token | sed 's/.*"access_token":"\([^"]*\).*/\1/')
 {% for network in discovery_networks %}
 magellan scan --subnet {{ network.cidr }}
+# XXX - This is the right place to do this, but it breaks everything
+#       right now because it arbitrarily overwrites already stored
+#       credentials on subsequent networks. Fix the logic here, then
+#       enable it again for all networks. For now, do it at the end
+#       and only for the internal network.
+{% if not network.external %}
+magellan list | awk '{print $1}' | xargs -I{} magellan secrets store {} {{ network.redfish_username }}:{{ network.redfish_password }}
+{% endif %}
+# XXX - End
 {% endfor %}
-magellan list
-cd /tmp/nobody/magellan
-magellan list | awk '{print $1}' | xargs -I{} magellan secrets store {} $emulator_username:$emulator_password
-magellan secrets list
 magellan secrets list | awk '{print $1}' | sed -e 's/:$//' | xargs -I{} magellan secrets retrieve {}
-export ACCESS_TOKEN=$(curl -s -X GET http://opaal:3333/token | sed 's/.*"access_token":"\([^"]*\).*/\1/')
 magellan collect -v --format yaml --output-file nodes.yaml
 magellan send --format yaml -d @nodes.yaml http://smd:27779 --access-token "$ACCESS_TOKEN"
 # The following is helpful for debugging. It keeps the container

--- a/vtds_application_openchami/private/templates/prepare_blade.sh
+++ b/vtds_application_openchami/private/templates/prepare_blade.sh
@@ -1,0 +1,54 @@
+#! /usr/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+set -e -o pipefail
+
+# Create the directory in /etc where all of the Sushy Tools setup will
+# go.
+mkdir -p /etc/sushy-emulator
+chmod 700 /etc/sushy-emulator
+
+# Make self-signed X509 cert / key for the sushy-emulator
+openssl req -x509 -nodes -newkey rsa:2048 -days 365 \
+        -keyout /etc/sushy-emulator/key.pem \
+        -out /etc/sushy-emulator/cert.pem \
+        -subj "/C=US/ST=SushyTools/L=Vtds/O=vTDS/CN=vtds"
+
+# Create an htpasswd file for the sushy-emulator to use
+{% for network in discovery_networks %}
+{% if network.external %}
+htpasswd -B -b -c /etc/sushy-emulator/users \
+         {{ network.redfish_username }} \
+         {{ network.redfish_password }}
+{% endif %}
+{% endfor %}
+
+# Put the sushy-emulator config away where it belongs...
+cp /root/sushy-emulator.conf /etc/sushy-emulator/config
+
+# Put the systemd unit file for sushy-emulator where it belongs
+cp /root/sushy-emulator.service /etc/systemd/system/sushy-emulator.service
+
+# Start up the sushy-emulator
+systemctl daemon-reload
+systemctl start sushy-emulator

--- a/vtds_application_openchami/private/templates/sushy-emulator.conf
+++ b/vtds_application_openchami/private/templates/sushy-emulator.conf
@@ -1,0 +1,6 @@
+SUSHY_EMULATOR_LISTEN_IP='0.0.0.0'
+SUSHY_EMULATOR_LISTEN_PORT=443
+SUSHY_EMULATOR_SSL_CERT='/etc/sushy-emulator/cert.pem'
+SUSHY_EMULATOR_SSL_KEY='/etc/sushy-emulator/key.pem'
+SUSHY_EMULATOR_LIBVIRT_URI='qemu:///system'
+SUSHY_EMULATOR_AUTH_FILE='/etc/sushy-emulator/users'

--- a/vtds_application_openchami/private/templates/sushy-emulator.service
+++ b/vtds_application_openchami/private/templates/sushy-emulator.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Sushy RedFish Emulator for vTDS
+After=syslog.target network.target
+
+[Service]
+Type=simple
+TimeoutStartSec=5m
+User=root
+WorkingDirectory=/root
+Environment="SUSHY_EMULATOR_LIBVIRT_BY_NAME=true"
+ExecStart=/root/blade-venv/bin/sushy-emulator --config /etc/sushy-emulator/config
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary and Scope

This PR adds the code to get sushi-emulator set up and running correctly on Virtual Blades on an OpenCHAMI cluster. There are still some issues with it working with compute nodes and magellan / SMD that need to be resolved, but those are being handled under a separate issue.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves VTDS-670

## Testing

Tested by deploying OpenCHAMI with 4 compute nodes defined on vTDS and verifying the sushy-emulator came up and was reachable on the hardware management network, could power cycle and reset the compute nodes, could talk to magellan (though not perfectly) and was reachable from inside the Docker containers. Also verified that a system with no compute nodes requested still worked as expected for RIE simulated RedFish endpoints that the system comes up cleanly in the phase I demo mode.