### PR TITLE
Add RIE configuration mechanism

### DIFF
--- a/vtds_application_openchami/private/config/config.yaml
+++ b/vtds_application_openchami/private/config/config.yaml
@@ -67,3 +67,83 @@ application:
       # own risk if you want a known value.
       redfish_username: root
       redfish_password: null
+  # The 'rie_services' section configures the RIE (Redfish Interface
+  # Emulator) instances that will be set up in the OpenCHAMI
+  # deployment. RIE instances provide simulated RedFish endpoints for
+  # discovery and node manipulation. They do not represent any actual
+  # BMCs or Node resources.  They are useful for standalone testing of
+  # OpenCHAMI without the need for actual Compute nodes and so forth.
+  #
+  # The first RIE service configuration is annotated to help with
+  # setting up an RIE service. The rest are left without annotation to
+  # avoid duplication.
+  rie_services:
+    rf-x0c0s1b0:
+      # delete tells vTDS whether or not to delete this RIE service from
+      # the configuration before bringing up RIE services. Set this to
+      # true to remove this RIE service from the OpenCHAMI system
+      delete: false
+      # container_name specifies the name of the container to be be run
+      # to start this RIE service.
+      container_name: rf-x0c0s1b0
+      # hostname provides the hostname on the RIE network of the service
+      hostname: x0c0s1b0
+      # Image specifies the RIE container image to be used to make this
+      # RIE service.
+      image: ghcr.io/openchami/csm-rie:latest
+      # The following environment variables tell RIE what to set up on
+      # this service
+      environment:
+        - MOCKUPFOLDER=EX235a
+        - MAC_SCHEMA=Mountain
+        - XNAME=x0c0s1b0
+        - PORT=443
+      # networks indicates what networks the RIE service will be present
+      # on within the OpenCHAMI cluster and provides the hostname
+      # aliases for this RIE service
+      networks:
+        internal:
+          aliases:
+            - x0c0s1b0
+    rf-x0c0s2b0:
+      delete: false
+      container_name: rf-x0c0s2b0
+      hostname: x0c0s2b0
+      image: ghcr.io/openchami/csm-rie:latest
+      environment:
+        - MOCKUPFOLDER=EX235a
+        - MAC_SCHEMA=Mountain
+        - XNAME=x0c0s2b0
+        - PORT=443
+      networks:
+        internal:
+          aliases:
+            - x0c0s2b0
+    rf-x0c0s3b0:
+      delete: false
+      container_name: rf-x0c0s3b0
+      hostname: x0c0s3b0
+      image: ghcr.io/openchami/csm-rie:latest
+      environment:
+        - MOCKUPFOLDER=EX235a
+        - MAC_SCHEMA=Mountain
+        - XNAME=x0c0s3b0
+        - PORT=443
+      networks:
+        internal:
+          aliases:
+            - x0c0s3b0
+    rf-x0c0s4b0:
+      delete: false
+      container_name: rf-x0c0s4b0
+      hostname: x0c0s4b0
+      image: ghcr.io/openchami/csm-rie:latest
+      environment:
+        - MOCKUPFOLDER=EX235a
+        - MAC_SCHEMA=Mountain
+        - XNAME=x0c0s4b0
+        - PORT=443
+      networks:
+        internal:
+          aliases:
+            - x0c0s4b0

--- a/vtds_application_openchami/private/templates/OpenCHAMI-Prepare.sh
+++ b/vtds_application_openchami/private/templates/OpenCHAMI-Prepare.sh
@@ -36,59 +36,7 @@ fail() {
 
 computes() {
     cat <<EOF
-services:
-  rf-x0c0s1b0:
-    container_name: rf-x0c0s1b0
-    hostname: x0c0s1b0
-    image: ghcr.io/openchami/csm-rie:latest
-    environment:
-      - MOCKUPFOLDER=EX235a
-      - MAC_SCHEMA=Mountain
-      - XNAME=x0c0s1b0
-      - PORT=443
-    networks:
-      internal:
-        aliases:
-          - x0c0s1b0
-  rf-x0c0s2b0:
-    container_name: rf-x0c0s2b0
-    hostname: x0c0s2b0
-    image: ghcr.io/openchami/csm-rie:latest
-    environment:
-      - MOCKUPFOLDER=EX235a
-      - MAC_SCHEMA=Mountain
-      - XNAME=x0c0s2b0
-      - PORT=443
-    networks:
-      internal:
-        aliases:
-          - x0c0s2b0
-  rf-x0c0s3b0:
-    container_name: rf-x0c0s3b0
-    hostname: x0c0s3b0
-    image: ghcr.io/openchami/csm-rie:latest
-    environment:
-      - MOCKUPFOLDER=EX235a
-      - MAC_SCHEMA=Mountain
-      - XNAME=x0c0s3b0
-      - PORT=443
-    networks:
-      internal:
-        aliases:
-          - x0c0s3b0
-  rf-x0c0s4b0:
-    container_name: rf-x0c0s4b0
-    hostname: x0c0s4b0
-    image: ghcr.io/openchami/csm-rie:latest
-    environment:
-      - MOCKUPFOLDER=EX235a
-      - MAC_SCHEMA=Mountain
-      - XNAME=x0c0s4b0
-      - PORT=443
-    networks:
-      internal:
-        aliases:
-          - x0c0s4b0
+services: {{ rie_services }}
 EOF
 }
 


### PR DESCRIPTION
## Summary and Scope

RIE is set up using a docker compose file that is generated during management node preparation. This PR provides base configuration and a mechanism to make the contents of that docker compose file configurable in vTDS, thereby permitting the user to control the number and contents of the RIE services.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [VSHA-673](https://jira-pro.it.hpe.com:8443/browse/VSHA-673)

## Testing

Tested by deploying the following configurations of OpenCHAMI on vTDS systems:

- One with the full complement of RIE endpoints configured using the base configuration unmodified
- One with all RIE endpoints removed using the Core Configuration to override the base configuration and delete them
- One with two of the RIE endpoints removed using the Core Configuration to override the base configuration and delete them

Observed both correct contents of the shells script used to generate the RIE Docker Compose files and of the output when querying the SMD for inventory discovered during OpenCHAMI startup in all three cases.
