### PR TITLE
Add BMC (Virtual Blade) Address to XNAME map generation

### DIFF
--- a/vtds_application_openchami/private/templates/OpenCHAMI-Remove.sh
+++ b/vtds_application_openchami/private/templates/OpenCHAMI-Remove.sh
@@ -44,3 +44,8 @@ docker compose \
        -f magellan_discovery.yml \
        down --volumes || \
     fail "removing OpenCHAMI deployment failed"
+
+cd /root || \
+    fail "cant chdir to /root"
+
+rm -rf deployment_recipes

--- a/vtds_application_openchami/private/templates/OpenCHAMI-Stage2-Deploy.sh
+++ b/vtds_application_openchami/private/templates/OpenCHAMI-Stage2-Deploy.sh
@@ -31,9 +31,9 @@ fail() {
 bmc_id_map() {
     echo "map_key: bmc-ip-addr"
     echo "id_map:"
-    # IP Address to XNAME mappings for Virtual Blades
+    # Address to XNAME mappings for Virtual Blades
     {% for bmc_mapping in bmc_mappings %}
-    echo "    {{ bmc_mapping.ip_addr }}: {{ bmc_mapping.xname }}"
+    echo "    {{ bmc_mapping.addr }}: {{ bmc_mapping.xname }}"
     {% endfor %}
     # IP Address to XNAME mappings for RIE containers
     docker ps --format json | jq -r '.Names | select(test("^rf-x"))' | while read container; do


### PR DESCRIPTION
## Summary and Scope

This PR completes support for Virtual Compute Nodes in OpenCHAMI on vTDS by providing an XNAME mapping that Magellan can use to identify "real" compute nodes on "real" BMCs and send the information to SMD.

## Issues and Related PRs

* Resolves [VSHA-679](https://jira-pro.it.hpe.com:8443/browse/VSHA-679)

## Testing

Tested on OpenCHAMI on vTDS systems both for systems with Virtual Compute nodes on blades served by "real" BMCs and for systems with only RIE based simulated nodes and BMCs. Verified that the data in SMD was correct.