### PR TITLE
Vsha 690

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,12 +41,8 @@ jobs:
       with:
         python-version: ${{ matrix.version }}
     - name: nox
-      env:
-        ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
-        ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
       run: |
-        ./runPrep.sh
         pip install --upgrade pip
-        pip install --extra-index-url=https://artifactory.algol60.net/artifactory/csm-python-modules/simple .[ci]
-        pip install --extra-index-url=https://artifactory.algol60.net/artifactory/csm-python-modules/simple .[lint]
+        pip install .[ci]
+        pip install .[lint]
         nox -e lint

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -41,11 +41,7 @@ jobs:
       with:
         python-version: ${{ matrix.version }}
     - name: nox
-      env:
-        ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
-        ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
       run: |
-        ./runPrep.sh
-        pip install --extra-index-url=https://artifactory.algol60.net/artifactory/csm-python-modules/simple .[ci]
-        pip install --extra-index-url=https://artifactory.algol60.net/artifactory/csm-python-modules/simple .[style]
+        pip install .[ci]
+        pip install .[style]
         nox -e style

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,11 +41,7 @@ jobs:
       with:
         python-version: ${{ matrix.version }}
     - name: nox
-      env:
-        ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
-        ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
       run: |
-        ./runPrep.sh
-        pip install --extra-index-url=https://artifactory.algol60.net/artifactory/csm-python-modules/simple .[ci]
-        pip install --extra-index-url=https://artifactory.algol60.net/artifactory/csm-python-modules/simple .[test]
+        pip install .[ci]
+        pip install .[test]
         nox -e tests

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -32,11 +32,6 @@ COVERAGE_FAIL = 95
 
 PYTHON = ['3']
 
-EXTRA_INDEX = (
-    "--extra-index-url="
-    "https://artifactory.algol60.net/artifactory/csm-python-modules/simple"
-)
-
 @nox.session(python=PYTHON)
 def lint(session):
     """Run linters.
@@ -48,7 +43,7 @@ def lint(session):
         'vtds_application_openchami',
     ]
     if session.python:
-        session.install(EXTRA_INDEX, '.[lint]')
+        session.install('.[lint]')
     session.run(*run_cmd)
 
 
@@ -64,7 +59,7 @@ def style(session):
     ]
  
     if session.python:
-        session.install(EXTRA_INDEX, '.[style]')
+        session.install('.[style]')
     session.run(*run_cmd)
 
 
@@ -75,7 +70,7 @@ def tests(session):
     # Install all test dependencies, then install this package in-place.
     path = 'tests'
     if session.python:
-        session.install(EXTRA_INDEX, '.[test]')
+        session.install('.[test]')
 
     # XXX - disable tests until we have some...
     session.run('/usr/bin/true', external=True)
@@ -104,7 +99,7 @@ def cover(session):
     test runs, and then erases coverage data.
     """
     if session.python:
-        session.install(EXTRA_INDEX, '.[cover]')
+        session.install('.[cover]')
     # Disable coverage tests until we have some...
     session.run('/usr/bin/true', external=True)
 #    session.run('coverage', 'report', '--show-missing',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ license = { file = 'LICENSE' }
 
 [project.optional-dependencies]
 build = [
-    'build~=1.2.2'
+    'build>=1.2.2,<1.4.0'
 ]
 ci = [
     'nox>=2024.10.9,<2025.6.0',
@@ -70,7 +70,7 @@ lint = [
     'pylint~=3.2',
 ]
 test = [
-    'pytest~=8.3.3',
+    'pytest>=8.3.3,<8.5.0',
     'pytest-cov>=4.1,<7.0',
     'coverage~=7.4',
 ]
@@ -89,7 +89,7 @@ exclude = ['vtds_application_openchami.tests*']
 build-backend = 'setuptools.build_meta'
 requires = [
     'setuptools >= 66,< 81',
-    'setuptools_scm[toml] >= 7.1,< 9.1',
+    'setuptools_scm[toml] >= 7.1,< 9.2',
     'wheel ~= 0.45.1',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,9 @@ classifiers = [
 ]
 description = 'Openchami Application Layer Plugin for the Virtual Test Development System (vTDS) suite'
 dependencies = [
+    # yaml - this comment reduces conflicts in dependabot PRs
     'pyyaml~=6.0',
+    # vtds base libraries - this comment reduces conflicts in dependabot PRs
     'vtds_base~=0.0',
 ]
 
@@ -70,8 +72,11 @@ lint = [
     'pylint~=3.2',
 ]
 test = [
+    # pytest - this comment reduces conflicts in dependabot PRs
     'pytest>=8.3.3,<8.5.0',
+    # pytest coverage - this comment reduces conflicts in dependabot PRs
     'pytest-cov>=4.1,<7.0',
+    # coverage - this comment reduces conflicts in dependabot PRs
     'coverage~=7.4',
 ]
 
@@ -88,8 +93,11 @@ exclude = ['vtds_application_openchami.tests*']
 [build-system]
 build-backend = 'setuptools.build_meta'
 requires = [
+    # setuptools - this comment reduces conflicts in dependabot PRs
     'setuptools >= 66,< 81',
+    # setuptools scm - this comment reduces conflicts in dependabot PRs
     'setuptools_scm[toml] >= 7.1,< 9.2',
+    # wheel - this comment reduces conflicts in dependabot PRs
     'wheel ~= 0.45.1',
 ]
 

--- a/vtds_application_openchami/private/__init__.py
+++ b/vtds_application_openchami/private/__init__.py
@@ -134,6 +134,34 @@ BARE_MANAGEMENT_NODE_FILES = [
 # Management node files for the Quadlet deployment mode
 QUADLET_MANAGEMENT_NODE_FILES = [
     (
+        template('quadlet/minio.container'),
+        home('minio.container'),
+        '644',
+        'minio_quadlet_container_config',
+        False,
+    ),
+    (
+        template('quadlet/registry.container'),
+        home('registry.container'),
+        '644',
+        'registry_quadlet_container_config',
+        False,
+    ),
+    (
+        template('quadlet/coredhcp.yaml'),
+        home('coredhcp.yaml'),
+        '644',
+        'coredhcp_config',
+        False,
+    ),
+    (
+        template('quadlet/OpenCHAMI-Prepare.sh'),
+        home('OpenCHAMI-Prepare.sh'),
+        '755',
+        'open-chami-prepare-script',
+        False,
+    ),
+    (
         template('quadlet/prepare_node.sh'),
         home('prepare_node.sh'),
         '755',

--- a/vtds_application_openchami/private/templates/bare/prepare_node.sh
+++ b/vtds_application_openchami/private/templates/bare/prepare_node.sh
@@ -61,8 +61,12 @@ dnf -y install ${PACKAGES}
 dnf -y install epel-release
 dnf -y install s3cmd
 systemctl enable --now libvirtd
-groupadd rocky
-useradd -g rocky -G libvirt rocky
+if ! getent group rocky; then
+    groupadd rocky
+fi
+if ! getent passwd rocky; then
+    useradd -g rocky -G libvirt rocky
+fi
 # Remove rocky from /etc/sudoers and then put it back with NOPASSWD access
 sed -i -e '/[[:space:]]*rocky/d' /etc/sudoers
 echo 'rocky ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers

--- a/vtds_application_openchami/private/templates/quadlet/OpenCHAMI-Prepare.sh
+++ b/vtds_application_openchami/private/templates/quadlet/OpenCHAMI-Prepare.sh
@@ -1,0 +1,159 @@
+#! /usr/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Set up the system level pieces needed to start deploying
+# OpenCHAMI. This script is intended to be run by a user with
+# passwordless 'sudo' permissions. The base node preparation script
+# sets up the user 'rocky' with that before chaining here.
+set -e -o pipefail
+
+function fail() {
+    msg="$*"
+    echo "ERROR: ${msg}" >&2
+    exit 1
+}
+
+# Some useful variables that can be templated
+HEADNODE_FQDN="demo.openchami.cluster"
+LIBVIRT_HEADNODE_IP="172.16.0.254"
+LIBVIRT_NET_LENGTH="24"
+LIBVIRT_NET_MASK="255.255.255.0"  # Computed from length when tempated
+NMN_HEADNODE_IP="10.1.1.11"  # XXX - This needs to be discovered or templated
+
+# Create the directories that are needed for deployment and must be
+# made by 'root'
+for dir in /data/oci /data/s3 /opt/workdir; do
+    echo "Making directory: ${dir}"
+    sudo mkdir -p "${dir}"
+    sudo chown -R rocky: "${dir}"
+done
+
+# Make the directories that are needed for deployment and can be made by rocky
+for dir in /opt/workdir/nodes /opt/workdir/images /opt/workdir/boot /opt/workdir/cloud-init; do
+    echo "Making directory: ${dir}"
+    mkdir -p '${dir}'
+done
+
+# Turn on IPv4 forwarding on the management node to allow other nodes
+# to reach OpenCHAMI services
+sudo sysctl -w net.ipv4.ip_forward=1
+
+# Create a virtual bridged network within libvirt to act as the node
+# local network used by OpenCHAMI services.
+#
+# XXX - Creation of this should be templated and configurable, as
+#       should the network IP and the head node IP.
+echo "Setting up libvirt bridge network for OpenCHAMI"
+cat <<EOF > openchami-net.xml
+<network>
+  <name>openchami-net</name>
+  <bridge name="virbr-openchami" />
+  <forward mode='route'/>
+   <ip address="${LIBVIRT_HEADNODE_IP}" netmask="${LIBVIRT_NET_MASK}">
+   </ip>
+</network>
+EOF
+sudo virsh net-destroy openchami-net || true
+sudo virsh net-undefine openchami-net || true
+sudo virsh net-define openchami-net.xml
+sudo virsh net-start openchami-net
+sudo virsh net-autostart openchami-net
+
+# Set up an /etc/hosts entry for the OpenCHAMI head node so we can use
+# it for certs and for reaching the services.
+#
+# XXX - This should be templated so it is configurable, both IP and FQDM
+echo "Adding head node (${LIBVIRT_HEADNODE_IP}) to /etc/hosts"
+echo "${LIBVIRT_HEADNODE_IP} ${HEADNODE_FQDN}" | sudo tee -a /etc/hosts > /dev/null
+
+# Set up the quadlet container definition to launch minio as an S3 server
+echo "Setting up minio container for quadlet service"
+sudo cp /root/minio.container /etc/containers/systemd/minio.container
+
+# Set up the quadlet container definition to launch a container registry
+echo "Setting up registry container for quadlet service"
+sudo cp /root/registry.container /etc/containers/systemd/registry.container
+
+# Reload systemd to pick up the minio and registry containers and then
+# start those services
+echo "Restarting systemd and starting minio and registry services"
+sudo systemctl daemon-reload
+sudo systemctl stop minio.service
+sudo systemctl start minio.service
+sudo systemctl stop registry.service
+sudo systemctl start registry.service
+
+# Install openchami from RPMs
+#
+# XXX - the VERSION here should be templated and configurable
+echo "Finding OpenCHAMI RPM"
+OWNER="openchami"
+REPO="release"
+OPENCHAMI_VERSION="latest"
+
+# Identify the version's release RPM
+API_URL="https://api.github.com/repos/${OWNER}/${REPO}/releases/${OPENCHAMI_VERSION}"
+release_json=$(curl -s "$API_URL")
+rpm_url=$(echo "$release_json" | jq -r '.assets[] | select(.name | endswith(".rpm")) | .browser_download_url' | head -n 1)
+rpm_name=$(echo "$release_json" | jq -r '.assets[] | select(.name | endswith(".rpm")) | .name' | head -n 1)
+
+# Download the RPM
+echo "Downloading OpenCHAMI RPM"
+curl -L -o "$rpm_name" "$rpm_url"
+
+# Install the RPM
+echo "Installing OpenCHAMI RPM"
+if systemctl status openchami.target; then
+    sudo systemctl stop openchami.target
+fi
+sudo rpm -Uvh --reinstall "$rpm_name"
+
+# Set up the CoreDHCP configuration to support network booting Compute Nodes
+echo "Setting up CoreDHCP Configuration"
+sudo cp /root/coredhcp.yaml /etc/openchami/configs/coredhcp.yaml
+
+# Set up Cluster SSL Certs for the
+#
+# XXX - this needs to be templated to use the configured FQDN of the head node
+echo "Setting up cluster SSL certs for OpenCHAMI"
+sudo openchami-certificate-update update demo.openchami.cluster
+
+# Start OpenCHAMI
+echo "Starting OpenCHAMI"
+sudo systemctl start openchami.target
+
+# Install the OpenCHAMI CLI client (ochami)
+echo "retrieving OpenCHAMI CLI (ochami) RPM"
+OCHAMI_CLI_VERSION="latest"
+latest_release_url=$(curl -s https://api.github.com/repos/OpenCHAMI/ochami/releases/${OCHAMI_CLI_VERSION} | jq -r '.assets[] | select(.name | endswith("amd64.rpm")) | .browser_download_url')
+curl -L "${latest_release_url}" -o ochami.rpm
+echo "Installing OpenCHAMI CLI (ochami) RPM"
+sudo dnf install -y ./ochami.rpm
+
+# Configure the OpenCHAMI CLI client
+#
+# XXX- This needs to be templated to use the configured FQDN of the head node
+echo "Configuring OpenCHAMI CLI (ochami) Client"
+sudo rm -f /etc/ochami/config.yaml
+echo y | sudo ochami config cluster set --system --default demo cluster.uri "https://demo.openchami.cluster:8443" || fail "failed to configure OpenCHAMI CLI"

--- a/vtds_application_openchami/private/templates/quadlet/coredhcp.yaml
+++ b/vtds_application_openchami/private/templates/quadlet/coredhcp.yaml
@@ -1,0 +1,47 @@
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Set up the system level pieces needed to start deploying
+# OpenCHAMI. This script is intended to be run by a user with
+# passwordless 'sudo' permissions. The base node preparation script
+# sets up the user 'rocky' with that before chaining here.
+
+# XXX - This needs lots of templating and needs to support multiple scopes
+#       so that we can use real Virtual Nodes
+server4:
+# You can configure the specific interfaces that you want OpenCHAMI to
+# listen on by uncommenting the lines below and setting the interface
+  listen:
+    - "%virbr-openchami"
+  plugins:
+# You are able to set the IP address of the system in server_id as the
+# place to look for a DHCP server DNS is able to be set to whatever you
+# want but it is much easier if you keep it set to the server IP Router
+# is also able to be set to whatever you network router address is
+    - server_id: 172.16.0.254
+    - dns: 172.16.0.254
+    - router: 172.16.0.254
+    - netmask: 255.255.255.0
+# The lines below define where the system should assign ip addresses for
+# systems that do not have mac addresses stored in SMD
+    - coresmd: https://demo.openchami.cluster:8443 http://172.16.0.254:8081 /root_ca/root_ca.crt 30s 1h false
+    - bootloop: /tmp/coredhcp.db default 5m 172.16.0.200 172.16.0.250

--- a/vtds_application_openchami/private/templates/quadlet/minio.container
+++ b/vtds_application_openchami/private/templates/quadlet/minio.container
@@ -1,0 +1,27 @@
+[Unit]
+Description=Minio S3
+After=local-fs.target network-online.target
+Wants=local-fs.target network-online.target
+
+[Container]
+ContainerName=minio-server
+Image=docker.io/minio/minio:latest
+# Volumes
+Volume=/data/s3:/data:Z
+
+# Ports
+PublishPort=9000:9000
+PublishPort=9001:9001
+
+# Environemnt Variables
+Environment=MINIO_ROOT_USER=admin
+Environment=MINIO_ROOT_PASSWORD=admin123
+
+# Command to run in container
+Exec=server /data --console-address :9001
+
+[Service]
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/vtds_application_openchami/private/templates/quadlet/nodes.yaml
+++ b/vtds_application_openchami/private/templates/quadlet/nodes.yaml
@@ -1,0 +1,44 @@
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Set up the system level pieces needed to start deploying
+# OpenCHAMI. This script is intended to be run by a user with
+# passwordless 'sudo' permissions. The base node preparation script
+# sets up the user 'rocky' with that before chaining here.
+nodes:
+{%- for node in nodes %}
+- name: {%-{ node.name }}
+  nid: {{ node.nid }}
+  xname: {{ node.xname }}
+  bmc_mac: {{ node.bmc_mac }}
+  bmc_ip: {{ node.bmc_ip }}
+  group: {{ node.node_class }}
+  interfaces:
+  {%- for interface in node.interfaces %}
+  - mac_addr: {{ interface.mac_addr }}
+    ip_addrs:
+    {%- for ip_addr in interfaces.ip_addrs %}
+    - name: {{ ip_addr.name }}
+      ip_addr: {{ ip_addr.ip_addr }}
+    {%- endfor }
+  {%- endfor %}
+{%- endfor %}

--- a/vtds_application_openchami/private/templates/quadlet/prepare_node.sh
+++ b/vtds_application_openchami/private/templates/quadlet/prepare_node.sh
@@ -61,8 +61,18 @@ dnf -y install ${PACKAGES}
 dnf -y install epel-release
 dnf -y install s3cmd
 systemctl enable --now libvirtd
-groupadd rocky
-useradd -g rocky -G libvirt rocky
+if ! getent group rocky; then
+    groupadd rocky
+fi
+if ! getent passwd rocky; then
+    useradd -g rocky -G libvirt rocky
+fi
 # Remove rocky from /etc/sudoers and then put it back with NOPASSWD access
 sed -i -e '/[[:space:]]*rocky/d' /etc/sudoers
 echo 'rocky ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+
+# Run OpenCHAMI preparation script as 'rocky'
+cp /root/OpenCHAMI-Prepare.sh ~rocky/OpenCHAMI-Prepare.sh
+chown rocky ~rocky/OpenCHAMI-Prepare.sh
+chmod 755 ~rocky/OpenCHAMI-Prepare.sh
+su - rocky -c "~rocky/OpenCHAMI-Prepare.sh"

--- a/vtds_application_openchami/private/templates/quadlet/registry.container
+++ b/vtds_application_openchami/private/templates/quadlet/registry.container
@@ -1,0 +1,18 @@
+[Unit]
+Description=Image OCI Registry
+After=network-online.target
+Requires=network-online.target
+
+[Container]
+ContainerName=registry
+HostName=registry
+Image=docker.io/library/registry:latest
+Volume=/data/oci:/var/lib/registry:Z
+PublishPort=5000:5000
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/vtds_application_openchami/private/templates/quickstart/OpenCHAMI-Stage2-Deploy.sh
+++ b/vtds_application_openchami/private/templates/quickstart/OpenCHAMI-Stage2-Deploy.sh
@@ -32,9 +32,9 @@ bmc_id_map() {
     echo "map_key: bmc-ip-addr"
     echo "id_map:"
     # Address to XNAME mappings for Virtual Blades
-    {% for bmc_mapping in bmc_mappings %}
+    {%- for bmc_mapping in bmc_mappings %}
     echo "    {{ bmc_mapping.addr }}: {{ bmc_mapping.xname }}"
-    {% endfor %}
+    {%- endfor %}
     # IP Address to XNAME mappings for RIE containers
     docker ps --format json | jq -r '.Names | select(test("^rf-x"))' | while read container; do
         xname="$(docker inspect "${container}" \

--- a/vtds_application_openchami/private/templates/quickstart/magellan_discovery.sh
+++ b/vtds_application_openchami/private/templates/quickstart/magellan_discovery.sh
@@ -40,7 +40,9 @@ cp /bmc-id-map.yaml .
 #       to use it this way.
 rm -f rf_servers
 touch rf_servers
-{% for network in discovery_networks %}
+
+{%- for network in discovery_networks %}
+# Scan and store creds for subnet {{ network.cidr }}
 magellan scan --subnet {{ network.cidr }}
 servers="$(magellan list | awk '{print $1}')"
 creds="{{ network.redfish_username }}:{{ network.redfish_password }}"
@@ -55,7 +57,8 @@ for server in ${servers}; do
     echo "${server}" >> rf_servers
 done
 {% endfor %}
-magellan secrets list | awk '{print $1}' | sed -e 's/:$//' | xargs -I{} magellan secrets retrieve {}
+
+# Collect and deliver the node data
 magellan collect -v --format yaml --output-file nodes.yaml --bmc-id-map @bmc-id-map.yaml
 magellan send --format yaml -d @nodes.yaml http://smd:27779 --access-token "$ACCESS_TOKEN"
 # The following is helpful for debugging. It keeps the container

--- a/vtds_application_openchami/private/templates/quickstart/prepare_node.sh
+++ b/vtds_application_openchami/private/templates/quickstart/prepare_node.sh
@@ -25,9 +25,9 @@ set -e -o pipefail
 
 # The following templated code is set up by the Application layer
 # deployment script before shipping this shell script to the node
-{% for host in hosts %}
+{%- for host in hosts %}
 HOST_MACS[{{ host.host_instance }}]={{ host.host_mac }}
-{% endfor %}
+{%- endfor %}
 HOST_NODE_CLASS="{{ host_node_class }}"
 # End of templated code
 


### PR DESCRIPTION
## Summary and Scope

Create initial templated node setup script and OpenCHAMI startup script that brings OpenCHAMI startup in the quadlet model to the end of Phase 1 of the OpenCHAMI 2025 Tutorial. This is the point where OpenCHAMI is running and ready to accept registration of boot artifacts and node discovery information and to allow for booting "compute" nodes under libvirt locally on the management node. While this does not yet address the actual vTDS topology where Virtual Compute nodes are hosted on Virtual Blades not the management node, it provides the basis for experimentation and development toward booting Virtual Compute nodes from OpenCHAMI across the management network, which will be the next step.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [VSHA-690](https://jira-pro.it.hpe.com:8443/browse/VSHA-690)

## Testing

Tested on vTDS using all three deployment models:

- Quickstart
- Quadlet
- Bare

All three systems came up and reached their expected running states.